### PR TITLE
Fix issue where python and python venv is not properly installed in the dockerfile devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -26,6 +26,8 @@ RUN apt-get update && \
     unzip \
     xclip \
     python3.12-venv \
+    python3 \
+    python3-venv \
     # Browser dependencies
     libnss3 \
     libnspr4 \


### PR DESCRIPTION
Add `python3` and `python3-venv` to the `system-deps` stage in the `.devcontainer/Dockerfile`.

* Add `python3` to the `system-deps` stage
* Add `python3-venv` to the `system-deps` stage

