### PR TITLE
Add BuildKit docs and cache warm script

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,10 @@
 {
   "name": "Ubuntu Noble with Docker in Docker",
   "build": {
-    "dockerfile": "Dockerfile"
+    "dockerfile": "Dockerfile",
+    "args": {
+      "BUILDKIT_INLINE_CACHE": "1"
+    }
   },
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2.12.2": {},
@@ -9,13 +12,14 @@
       "installZsh": true,
       "configureZshAsDefaultShell": true,
       "installOhMyZsh": true
-    }
+    },
+    "buildkit": {}
   },
   "runArgs": [
     "--privileged"
   ],
   "remoteUser": "vscode",
-  "postCreateCommand": "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash; set -e && curl -sS https://webinstall.dev/k9s | sh && curl -LsSf https://astral.sh/uv/install.sh | sh",
+  "postCreateCommand": "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash; set -e && curl -sS https://webinstall.dev/k9s | sh && curl -LsSf https://astral.sh/uv/install.sh | sh && bash .devcontainer/init-buildkit.sh",
   "customizations": {
     "vscode": {
       "settings": {
@@ -28,5 +32,10 @@
         "ms-python.python"
       ]
     }
+  },
+  "remoteEnv": {
+    "DOCKER_BUILDKIT": "1",
+    "COMPOSE_DOCKER_CLI_BUILD": "1",
+    "COMPOSE_BAKE": "true"
   }
 }

--- a/.devcontainer/init-buildkit.sh
+++ b/.devcontainer/init-buildkit.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+if command -v docker >/dev/null; then
+  echo "Warming BuildKit cache via docker compose bake…"
+  docker compose bake --pull --load
+fi

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 [![Open in DevPod!](https://devpod.sh/assets/open-in-devpod.svg)](https://devpod.sh/open#https://github.com/joshyorko/room-of-requirement)
 
+See [docs/buildkit-devcontainer.md](docs/buildkit-devcontainer.md) for BuildKit and Moby cache instructions.

--- a/docs/buildkit-devcontainer.md
+++ b/docs/buildkit-devcontainer.md
@@ -1,0 +1,53 @@
+# Devcontainer BuildKit and Moby Cache Setup
+
+This guide explains how to enable Docker BuildKit inside the devcontainer, warm a Moby cache on start, and use `docker compose bake` for fast image builds.
+
+## 1. Current Environment Overview
+- **devcontainer.json** builds the container from `.devcontainer/Dockerfile` and installs Docker-in-Docker with common utilities.
+- The Dockerfile pulls a shared `.zshrc` which sets `COMPOSE_BAKE=true` to instruct Docker Compose to prefer BuildKit.
+- BuildKit can be toggled globally using `DOCKER_BUILDKIT=1`. A warmed "Moby cache" refers to pre-populated BuildKit layers so initial builds run quickly.
+
+## 2. Enable BuildKit
+Add BuildKit variables and arguments in `.devcontainer/devcontainer.json`:
+```json
+"build": {
+  "dockerfile": "Dockerfile",
+  "args": { "BUILDKIT_INLINE_CACHE": "1" }
+},
+"remoteEnv": {
+  "DOCKER_BUILDKIT": "1",
+  "COMPOSE_DOCKER_CLI_BUILD": "1",
+  "COMPOSE_BAKE": "true"
+},
+"features": {
+  "buildkit": {}
+}
+```
+These settings ensure BuildKit is used for all Docker commands in the devcontainer.
+
+## 3. Pre‑Warm the Moby Cache
+Create `.devcontainer/init-buildkit.sh`:
+```bash
+#!/usr/bin/env bash
+set -e
+if command -v docker >/dev/null; then
+  echo "Warming BuildKit cache via docker compose bake…"
+  docker compose bake --pull --load
+fi
+```
+Then extend `postCreateCommand`:
+```json
+"postCreateCommand": "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash; set -e && curl -sS https://webinstall.dev/k9s | sh && curl -LsSf https://astral.sh/uv/install.sh | sh && bash .devcontainer/init-buildkit.sh"
+```
+The script runs on container creation, fetching cache layers so subsequent builds are faster.
+
+## 4. Verification Steps
+- Check BuildKit builder size: `docker buildx du`.
+- Clean caches if needed: `docker builder prune`.
+- Benchmark build times before/after enabling the cache by running `time docker compose build`.
+
+## 5. Alternative Approaches
+- **Buildx inline cache** – push images with `--build-arg BUILDKIT_INLINE_CACHE=1` so future builds reuse layers without separate cache exports.
+- **devcontainers/cache feature** – mount a named volume for BuildKit caches to persist across container restarts.
+
+Use inline caching when publishing images and `devcontainers/cache` when persistent local caches are preferred.


### PR DESCRIPTION
## Summary
- document using BuildKit and Moby cache
- link docs from README
- add init-buildkit.sh to warm cache
- enable BuildKit in `devcontainer.json`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68643cd152f0832a87215ee4892cb352