### PR TITLE
fix: use nftables for Wolfi Docker networking

### DIFF
--- a/src/wolfi/.devcontainer/Dockerfile
+++ b/src/wolfi/.devcontainer/Dockerfile
@@ -76,6 +76,9 @@ RUN apk add --no-cache \
     docker-dind-compat \
     dockerd-oci-entrypoint \
     fuse-overlayfs \
+    iptables-nft \
+    iptables-wrappers \
+    nftables \
     # Playwright and browser dependencies (headless Chromium support)
     # Playwright installed via Wolfi package for proper system integration
     # Based on wolfi-dev/os chromium.yaml runtime dependencies

--- a/tests/ror-docker-start-test.sh
+++ b/tests/ror-docker-start-test.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 STARTER="${ROOT_DIR}/src/common/scripts/ror-docker-start.sh"
+WOLFI_DOCKERFILE="${ROOT_DIR}/src/wolfi/.devcontainer/Dockerfile"
 
 fail() {
     echo "FAIL: $*" >&2
@@ -59,6 +60,11 @@ assert_not_contains() {
 
     [[ "${haystack}" != *"${needle}"* ]] || fail "${label}: did not expect ${needle} in: ${haystack}"
 }
+
+for package in iptables-wrappers iptables-nft nftables; do
+    grep -Eq "^[[:space:]]*${package}[[:space:]\\]*$" "${WOLFI_DOCKERFILE}" || \
+        fail "Wolfi Dockerfile must install ${package} for nftables-compatible Docker networking"
+done
 
 plan="$(run_plan overlay 1 1)"
 assert_contains "${plan}" "--storage-driver=fuse-overlayfs" "overlay data root with usable fuse"


### PR DESCRIPTION
## What changed

- install iptables-nft, iptables-wrappers, and nftables in the Wolfi image
- make the iptables wrapper select the nftables frontend on nftables kernels
- keep Docker bridge and NAT networking enabled
- add a regression assertion to the Docker starter test

## Root cause

The Wolfi image exposed only iptables v1.8.13 legacy. On Bluefin's nftables host kernel, dockerd exited while creating the legacy DOCKER NAT chain, leaving Camp workspaces without a usable image engine.

## Verification

- bash tests/ror-docker-start-test.sh
- docker build -t ror-issue308 -f src/wolfi/.devcontainer/Dockerfile .
- privileged runtime reports iptables v1.8.13 nf_tables
- docker info succeeds
- docker pull alpine:3.20 succeeds
- a nested container reaches https://example.com with normal bridge/NAT networking
- docker network inspect bridge succeeds
- git diff --check

Fixes #308. Unblocks joshyorko/camp#27.