### PR TITLE
feat: add rootless Podman to Wolfi devcontainer

### DIFF
--- a/.github/workflows/build-devcontainers.yml
+++ b/.github/workflows/build-devcontainers.yml
@@ -170,6 +170,33 @@ jobs:
             exit 1
           '
 
+      - name: Verify Wolfi rootless Podman contract
+        if: matrix.variant == 'wolfi'
+        env:
+          BUILT_IMAGE: ${{ steps.build.outputs.image }}
+        run: |
+          set -euo pipefail
+
+          container="$(docker ps --filter "ancestor=${BUILT_IMAGE}" --format '{{.ID}}' | head -n 1)"
+          test -n "${container}"
+          docker exec --user vscode "${container}" bash --noprofile --norc -c '
+            set -euo pipefail
+            command -v podman
+            command -v buildah
+            command -v skopeo
+            test "$(stat -c %a "${XDG_RUNTIME_DIR}")" = 700
+            podman_info="$(podman info --format "{{.Host.Security.Rootless}} {{.Store.GraphDriverName}} {{.Host.NetworkBackend}} {{.Host.CgroupManager}}")"
+            test "${podman_info}" = "true overlay netavark cgroupfs"
+            podman run --rm alpine:3.22 sh -c "wget -q -O- https://example.com >/dev/null"
+            podman run --rm --cpus 0.25 alpine:3.22 true
+            bind_dir="$(mktemp -d)"
+            trap "rm -rf \"${bind_dir}\"" EXIT
+            printf "wolfi-podman\n" > "${bind_dir}/marker"
+            test "$(podman run --rm -v "${bind_dir}:/mnt:ro" alpine:3.22 cat /mnt/marker)" = "wolfi-podman"
+            buildah info >/dev/null
+            skopeo inspect docker://docker.io/library/alpine:3.22 >/dev/null
+          '
+
       - name: Tag and push variant aliases
         env:
           REGISTRY: ${{ env.REGISTRY }}

--- a/.github/workflows/build-devcontainers.yml
+++ b/.github/workflows/build-devcontainers.yml
@@ -177,8 +177,12 @@ jobs:
         run: |
           set -euo pipefail
 
-          container="$(docker ps --filter "ancestor=${BUILT_IMAGE}" --format '{{.ID}}' | head -n 1)"
-          test -n "${container}"
+          container="$(docker run -d --privileged "${BUILT_IMAGE}" sleep infinity)"
+          cleanup() {
+            docker rm -f "${container}" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
           docker exec --user vscode "${container}" bash --noprofile --norc -c '
             set -euo pipefail
             command -v podman
@@ -187,12 +191,12 @@ jobs:
             test "$(stat -c %a "${XDG_RUNTIME_DIR}")" = 700
             podman_info="$(podman info --format "{{.Host.Security.Rootless}} {{.Store.GraphDriverName}} {{.Host.NetworkBackend}} {{.Host.CgroupManager}}")"
             test "${podman_info}" = "true overlay netavark cgroupfs"
-            podman run --rm alpine:3.22 sh -c "wget -q -O- https://example.com >/dev/null"
-            podman run --rm --cpus 0.25 alpine:3.22 true
+            podman run --rm docker.io/library/alpine:3.22 sh -c "wget -q -O- https://example.com >/dev/null"
+            podman run --rm --cpus 0.25 docker.io/library/alpine:3.22 true
             bind_dir="$(mktemp -d)"
             trap "rm -rf \"${bind_dir}\"" EXIT
             printf "wolfi-podman\n" > "${bind_dir}/marker"
-            test "$(podman run --rm -v "${bind_dir}:/mnt:ro" alpine:3.22 cat /mnt/marker)" = "wolfi-podman"
+            test "$(podman run --rm -v "${bind_dir}:/mnt:ro" docker.io/library/alpine:3.22 cat /mnt/marker)" = "wolfi-podman"
             buildah info >/dev/null
             skopeo inspect docker://docker.io/library/alpine:3.22 >/dev/null
           '

--- a/README.md
+++ b/README.md
@@ -356,6 +356,12 @@ container runs work under project-container hosts such as DevPod and
 Codespaces. `docker info` and `docker run --rm hello-world` should work without
 a manual `ujust` repair step.
 
+The Wolfi stream also provides rootless `podman`, `buildah`, and `skopeo` for
+the `vscode` user. Podman uses a separate named storage volume and the
+Homebrew-provided `pasta` network helper; it does not replace the Docker CLI,
+daemon, socket, or storage. Use `podman info` and `podman run --rm alpine:3.22
+true` to verify the additional runtime.
+
 ---
 
 ## 📄 License

--- a/docs/superpowers/specs/2026-08-16-wolfi-podman-design.md
+++ b/docs/superpowers/specs/2026-08-16-wolfi-podman-design.md
@@ -1,0 +1,125 @@
+# Wolfi Podman Design
+
+## Goal
+
+Add Podman to the Wolfi image as a supported container tool alongside the
+existing Docker-in-Docker runtime. Docker remains the default compatibility
+contract; Podman is an additional native CLI and rootless runtime for the
+`vscode` user.
+
+## Architecture
+
+Install `podman-6.0`, `buildah`, `skopeo`, `shadow-subids`, and `mount` from
+Wolfi's signed APK repositories. Podman's package dependencies provide matching
+Wolfi builds of `conmon`, `containers-common`, `crun`, and `netavark`.
+
+Podman 6 requires `pasta` for rootless networking and has removed
+`slirp4netns` support. Wolfi does not currently package `passt`, so install the
+official Homebrew `passt` formula with the image's existing Homebrew foundation.
+This reuses a repository-supported, checksummed supply-chain path and keeps
+`pasta` on the image-wide `PATH`. Do not download an unverified binary or add a
+foreign APK repository.
+
+Configure a non-overlapping 65,536-ID subordinate UID and GID range for
+`vscode` after that user exists. Wolfi's `shadow-subids` package does not set
+the setuid bit on `newuidmap` and `newgidmap`; enable it explicitly so rootless
+user namespaces work. Limit the privilege to those standard mapping helpers.
+
+Install a user-level `storage.conf` with
+`rootless_storage_path = "$HOME/.local/share/containers/storage"` and
+`fuse-overlayfs` as the overlay mount program. Wolfi's system storage
+configuration otherwise directs this workload to root-owned
+`/var/lib/containers/storage`. Keep Podman's state separate from Docker's
+`/var/lib/docker` volume.
+
+At entrypoint startup, create an owner-only `/run/user/<current-vscode-uid>`,
+export it as `XDG_RUNTIME_DIR`, repair ownership of Podman's persistent storage
+volume, and make `/` recursively shared when Podman is installed. Computing the
+runtime path dynamically preserves Dev Container UID remapping.
+
+Podman does not replace or wrap Docker. The image keeps the `docker` binary,
+Docker daemon, Docker group, Docker socket, entrypoint startup behavior, and
+`ROR_DOCKER_*` controls unchanged. No `docker` alias or Podman socket is enabled
+by default.
+
+## UBlue Relationship
+
+`ublue-os/devcontainer` establishes the useful behavioral pattern: install
+Podman, allocate subordinate IDs, enable `newuidmap` and `newgidmap`, use
+persistent container storage, make the root mount shared, and prepare cgroup
+nesting for nested operation. Its implementation is not copied because it
+depends on Fedora packages, `dnf5`, `podman-machine`, bootc conventions, a
+broadly writable `/run/user`, and a feature entrypoint that would compete with
+this repository's existing Docker entrypoint.
+
+The Wolfi implementation adopts the portable contracts that live testing proves
+necessary: native distribution packages, setuid mapping helpers, explicit
+rootless storage, `pasta` networking, a per-user runtime directory, shared mount
+propagation, and runtime verification. It does not copy UBlue's `timedatectl`
+shim, Podman Machine packages, signing parameter file, bash startup bind mount,
+or unconditional cgroup reparenting. A privileged Wolfi probe successfully ran
+a CPU-limited rootless container with the `cgroupfs` manager without the latter.
+
+## Runtime Behavior
+
+- `docker` continues to use the existing Docker-in-Docker daemon and socket.
+- `podman` runs rootless when invoked by `vscode` and does not require a
+  long-lived daemon.
+- Podman uses its own per-user storage and network configuration.
+- A named Dev Container volume persists Podman's user storage independently of
+  Docker data.
+- The Wolfi devcontainer remains privileged, as already required for Docker
+  and nested container workloads.
+- Failure to initialize Podman must not change Docker startup or prevent the
+  devcontainer command from running.
+
+## Security and Supply Chain
+
+- Consume Podman and its OCI runtime dependencies exclusively from the same
+  signed Wolfi repositories as the base image.
+- Consume the missing `passt` dependency through the official Homebrew formula,
+  whose source or bottle is checksum-verified by Homebrew. This is the same
+  package channel already trusted by the image and avoids a new repository or
+  ad hoc installer.
+- Let Wolfi resolve Podman's runtime dependency set so Podman, conmon, crun,
+  and netavark remain compatible and receive normal Wolfi security rebuilds.
+- Keep the package set explicit and omit `podman-machine`, which is intended
+  for managing a separate VM and is unnecessary inside this Linux container.
+- Restrict `/run/user/<uid>` to its owner instead of adopting UBlue's mode
+  `0777` on all of `/run/user`.
+- Do not expose a Podman API socket or TCP endpoint by default.
+- Preserve the existing image SBOM, signing, and vulnerability-scanning
+  workflow for the added packages.
+
+## Validation
+
+Add a focused repository contract test that verifies the Wolfi Dockerfile:
+
+- installs `podman-6.0`, `buildah`, `skopeo`, `shadow-subids`, `mount`, and the
+  Homebrew `passt` formula;
+- defines subordinate UID and GID ranges for `vscode`;
+- sets the required setuid bits only on `newuidmap` and `newgidmap`;
+- selects `fuse-overlayfs` for rootless Podman storage;
+- prepares a dynamic, owner-only `XDG_RUNTIME_DIR` and persistent storage path;
+- does not alias or replace the `docker` command.
+
+Extend the Wolfi publish-time runtime contract to run as `vscode` and verify:
+
+- `podman`, `buildah`, and `skopeo` are present;
+- `podman info` reports rootless mode, overlay storage, `netavark`, and
+  `cgroupfs`;
+- a minimal container can be pulled and run with DNS and outbound networking;
+- a CPU-limited container and a bind-mounted container both run successfully;
+- `buildah info` and `skopeo inspect` succeed as `vscode`;
+- the existing Docker version, daemon, and `hello-world` checks still pass.
+
+Local verification uses the focused shell contract test, repository linting,
+and a Wolfi devcontainer build when the required build tooling is available.
+
+## Non-Goals
+
+- Replacing Docker or making Podman the implementation behind `docker`.
+- Adding Podman to Ubuntu Noble or Debian Trixie.
+- Running a Podman API service automatically.
+- Supporting `podman machine` inside the devcontainer.
+- Refactoring the shared Docker entrypoint or storage-startup code.

--- a/src/common/entrypoint.sh
+++ b/src/common/entrypoint.sh
@@ -49,6 +49,40 @@ fix_user_dir_permissions "${HOME}/.local/share/mise" "mise cache"
 fix_user_dir_permissions "${HOME}/.zsh_history_dir" "zsh history"
 fix_user_dir_permissions "${HOME}/.npm" "npm cache"
 
+# Prepare rootless Podman without changing Docker's startup contract. The
+# runtime directory follows the effective vscode UID because Dev Containers
+# may remap it at launch, and persistent storage may arrive root-owned.
+prepare_podman_runtime() {
+    command -v podman >/dev/null 2>&1 || return 0
+    id vscode >/dev/null 2>&1 || return 0
+
+    local vscode_uid
+    local runtime_dir
+    local podman_storage
+    vscode_uid="$(id -u vscode)"
+    runtime_dir="/run/user/${vscode_uid}"
+    podman_storage="${HOME}/.local/share/containers/storage"
+
+    run_as_root mkdir -p "${runtime_dir}" "${podman_storage}" 2>/dev/null || {
+        log "Warning: Failed to create Podman runtime or storage directories"
+        return 0
+    }
+    run_as_root chown vscode:vscode "${runtime_dir}" 2>/dev/null || \
+        log "Warning: Failed to chown Podman runtime or storage directories"
+    run_as_root chown -R vscode:vscode "${podman_storage}" 2>/dev/null || \
+        log "Warning: Failed to chown Podman storage contents"
+    run_as_root chmod 700 "${runtime_dir}" 2>/dev/null || \
+        log "Warning: Failed to restrict Podman runtime directory"
+    export XDG_RUNTIME_DIR="${runtime_dir}"
+
+    if command -v mount >/dev/null 2>&1; then
+        run_as_root mount --make-rshared / 2>/dev/null || \
+            log "Warning: Could not make root mount recursively shared"
+    fi
+}
+
+prepare_podman_runtime
+
 if [ -x /usr/local/share/docker-init.sh ] && [ "${ROR_USE_DEVCONTAINER_DOCKER_INIT:-1}" != "0" ]; then
     log "Delegating Docker startup to Dev Container Docker-in-Docker feature"
     exec /usr/local/share/docker-init.sh "$@"

--- a/src/wolfi/.devcontainer/Dockerfile
+++ b/src/wolfi/.devcontainer/Dockerfile
@@ -76,6 +76,11 @@ RUN apk add --no-cache \
     docker-dind-compat \
     dockerd-oci-entrypoint \
     fuse-overlayfs \
+    podman-6.0 \
+    buildah \
+    skopeo \
+    shadow-subids \
+    mount \
     iptables-nft \
     iptables-wrappers \
     nftables \
@@ -133,6 +138,9 @@ FROM base AS users
 RUN groupadd -g 999 docker && \
     groupadd -g 1000 vscode && \
     useradd -m -u 1000 -g vscode -G docker -s /bin/zsh vscode && \
+    echo "vscode:100000:65536" >> /etc/subuid && \
+    echo "vscode:100000:65536" >> /etc/subgid && \
+    chmod u+s /usr/bin/newuidmap /usr/bin/newgidmap && \
     echo "vscode ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/vscode && \
     chmod 0440 /etc/sudoers.d/vscode
 
@@ -211,7 +219,7 @@ ENV HOMEBREW_PREFIX=/home/linuxbrew/.linuxbrew \
 
 # Install the always-on shell foundation directly in the image.
 # Heavier curated tool bundles, including bbrew, stay opt-in through ujust recipes.
-RUN su - linuxbrew -c "/home/linuxbrew/.linuxbrew/bin/brew install starship mise zoxide"
+RUN su - linuxbrew -c "/home/linuxbrew/.linuxbrew/bin/brew install starship mise zoxide passt"
 
 # Configure Homebrew permissions for vscode user
 # vscode user needs full write access to Homebrew repo for `brew update`
@@ -335,7 +343,15 @@ RUN mkdir -p \
     /home/vscode/.cache \
     /home/vscode/.local/share \
     /home/vscode/.config/mise \
+    /home/vscode/.config/containers \
     /workspaces && \
+    printf '%s\n' \
+        '[storage]' \
+        'driver = "overlay"' \
+        'rootless_storage_path = "$HOME/.local/share/containers/storage"' \
+        '[storage.options.overlay]' \
+        'mount_program = "/usr/bin/fuse-overlayfs"' \
+        > /home/vscode/.config/containers/storage.conf && \
     chown -R vscode:vscode /home/vscode /workspaces && \
     chmod 755 /workspaces
     # NOTE: Keeping build-base/gcc and all *-dev packages for Ruby compilation via mise

--- a/src/wolfi/.devcontainer/Dockerfile
+++ b/src/wolfi/.devcontainer/Dockerfile
@@ -138,8 +138,8 @@ FROM base AS users
 RUN groupadd -g 999 docker && \
     groupadd -g 1000 vscode && \
     useradd -m -u 1000 -g vscode -G docker -s /bin/zsh vscode && \
-    echo "vscode:100000:65536" >> /etc/subuid && \
-    echo "vscode:100000:65536" >> /etc/subgid && \
+    if ! grep -q '^vscode:' /etc/subuid; then echo "vscode:100000:65536" >> /etc/subuid; fi && \
+    if ! grep -q '^vscode:' /etc/subgid; then echo "vscode:100000:65536" >> /etc/subgid; fi && \
     chmod u+s /usr/bin/newuidmap /usr/bin/newgidmap && \
     echo "vscode ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/vscode && \
     chmod 0440 /etc/sudoers.d/vscode

--- a/src/wolfi/.devcontainer/devcontainer.json
+++ b/src/wolfi/.devcontainer/devcontainer.json
@@ -21,7 +21,8 @@
     "source=ror-mise-cache,target=/home/vscode/.local/share/mise,type=volume",
     "source=ror-npm-cache,target=/home/vscode/.npm,type=volume",
     "source=ror-zsh-history,target=/home/vscode/.zsh_history_dir,type=volume",
-    "source=ror-docker-data,target=/var/lib/docker,type=volume"
+    "source=ror-docker-data,target=/var/lib/docker,type=volume",
+    "source=ror-wolfi-podman-storage,target=/home/vscode/.local/share/containers/storage,type=volume"
   ],
   "customizations": {
     "vscode": {

--- a/tests/wolfi-podman-contract-test.sh
+++ b/tests/wolfi-podman-contract-test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DOCKERFILE="${ROOT_DIR}/src/wolfi/.devcontainer/Dockerfile"
+ENTRYPOINT="${ROOT_DIR}/src/common/entrypoint.sh"
+DEVCONTAINER="${ROOT_DIR}/src/wolfi/.devcontainer/devcontainer.json"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+assert_contains() {
+    local file="$1"
+    local pattern="$2"
+    local label="$3"
+    grep -Eq "${pattern}" "${file}" || fail "${label}: ${pattern} not found in ${file}"
+}
+
+assert_not_contains() {
+    local file="$1"
+    local pattern="$2"
+    local label="$3"
+    if grep -Eq "${pattern}" "${file}"; then
+        fail "${label}: unexpected ${pattern} in ${file}"
+    fi
+}
+
+for package in podman-6.0 buildah skopeo shadow-subids mount; do
+    assert_contains "${DOCKERFILE}" "^[[:space:]]*${package}[[:space:]\\]*$" \
+        "Wolfi Podman package"
+done
+
+assert_contains "${DOCKERFILE}" 'brew install.*passt|brew install passt' \
+    "Homebrew pasta provider"
+assert_contains "${DOCKERFILE}" 'echo[[:space:]]+"vscode:[^" ]+:[^" ]+"[[:space:]]*>>[[:space:]]*/etc/subuid' \
+    "subordinate UID range"
+assert_contains "${DOCKERFILE}" 'echo[[:space:]]+"vscode:[^" ]+:[^" ]+"[[:space:]]*>>[[:space:]]*/etc/subgid' \
+    "subordinate GID range"
+assert_contains "${DOCKERFILE}" 'chmod[[:space:]]+u\+s[[:space:]]+/usr/bin/newuidmap[[:space:]]+/usr/bin/newgidmap' \
+    "setuid mapping helpers"
+assert_contains "${DOCKERFILE}" 'rootless_storage_path[[:space:]]*=[[:space:]]*"\$HOME/.local/share/containers/storage"' \
+    "rootless storage path"
+assert_contains "${DOCKERFILE}" 'mount_program[[:space:]]*=[[:space:]]*"/usr/bin/fuse-overlayfs"' \
+    "fuse-overlayfs storage"
+assert_contains "${ENTRYPOINT}" 'XDG_RUNTIME_DIR' "dynamic runtime directory"
+assert_contains "${ENTRYPOINT}" 'mount --make-rshared /' "shared root mount"
+assert_contains "${DEVCONTAINER}" 'ror-wolfi-podman-storage' "separate Podman storage volume"
+assert_contains "${DEVCONTAINER}" 'target=/home/vscode/.local/share/containers/storage' \
+    "Podman storage volume target"
+assert_not_contains "${DOCKERFILE}" 'alias[[:space:]]+docker[[:space:]]*=' \
+    "Docker command replacement"
+assert_not_contains "${ENTRYPOINT}" 'podman system service' \
+    "Podman API service"
+
+echo "Wolfi Podman contract tests passed"

--- a/tests/wolfi-podman-contract-test.sh
+++ b/tests/wolfi-podman-contract-test.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DOCKERFILE="${ROOT_DIR}/src/wolfi/.devcontainer/Dockerfile"
 ENTRYPOINT="${ROOT_DIR}/src/common/entrypoint.sh"
 DEVCONTAINER="${ROOT_DIR}/src/wolfi/.devcontainer/devcontainer.json"
+WORKFLOW="${ROOT_DIR}/.github/workflows/build-devcontainers.yml"
 
 fail() {
     echo "FAIL: $*" >&2
@@ -38,6 +39,10 @@ assert_contains "${DOCKERFILE}" 'echo[[:space:]]+"vscode:[^" ]+:[^" ]+"[[:space:
     "subordinate UID range"
 assert_contains "${DOCKERFILE}" 'echo[[:space:]]+"vscode:[^" ]+:[^" ]+"[[:space:]]*>>[[:space:]]*/etc/subgid' \
     "subordinate GID range"
+assert_contains "${DOCKERFILE}" "grep[[:space:]]+-q[[:space:]]+'\\^vscode:'[[:space:]]+/etc/subuid" \
+    "subordinate UID range is duplicate-safe"
+assert_contains "${DOCKERFILE}" "grep[[:space:]]+-q[[:space:]]+'\\^vscode:'[[:space:]]+/etc/subgid" \
+    "subordinate GID range is duplicate-safe"
 assert_contains "${DOCKERFILE}" 'chmod[[:space:]]+u\+s[[:space:]]+/usr/bin/newuidmap[[:space:]]+/usr/bin/newgidmap' \
     "setuid mapping helpers"
 assert_contains "${DOCKERFILE}" 'rootless_storage_path[[:space:]]*=[[:space:]]*"\$HOME/.local/share/containers/storage"' \
@@ -53,5 +58,13 @@ assert_not_contains "${DOCKERFILE}" 'alias[[:space:]]+docker[[:space:]]*=' \
     "Docker command replacement"
 assert_not_contains "${ENTRYPOINT}" 'podman system service' \
     "Podman API service"
+assert_contains "${WORKFLOW}" 'container="\$\(docker run -d --privileged "\$\{BUILT_IMAGE\}" sleep infinity\)"' \
+    "Podman smoke owns its container lifecycle"
+assert_contains "${WORKFLOW}" 'docker rm -f "\$\{container\}"' \
+    "Podman smoke cleans up its container"
+assert_not_contains "${WORKFLOW}" 'docker ps --filter "ancestor=' \
+    "Podman smoke does not reuse a prior step container"
+assert_contains "${WORKFLOW}" 'docker.io/library/alpine:3\.22' \
+    "Podman smoke uses fully qualified Alpine image"
 
 echo "Wolfi Podman contract tests passed"


### PR DESCRIPTION
## Summary

- add Wolfi-native Podman, Buildah, Skopeo, subordinate-ID helpers, and rootless overlay storage
- supply Podman 6 rootless networking through the official Homebrew `passt` formula
- prepare an owner-only runtime directory and separate persistent Podman storage without changing Docker
- add focused contract coverage and a privileged Wolfi runtime smoke to CI

## Why

The Wolfi stream already provides Docker-in-Docker but did not include Podman. A package-only Podman installation is incomplete on current Wolfi: mapping helpers lack the required setuid bits, the default storage configuration points rootless users at root-owned storage, and Podman 6 requires `pasta` while Wolfi does not package `passt`.

This adopts the portable parts of `ublue-os/devcontainer` while keeping the existing Docker CLI, daemon, socket, entrypoint, and storage contracts intact.

## Validation

- `tests/wolfi-podman-contract-test.sh`
- `tests/ror-docker-start-test.sh`
- shell, JSON, YAML, and diff syntax checks
- Wolfi devcontainer image build as `ror-wolfi-podman-verify:latest`
- rootless `podman info` reporting overlay, Netavark, and cgroupfs
- networked, CPU-limited, and bind-mounted Podman containers
- rootless `buildah info` and `skopeo inspect`
- Docker `hello-world` with Docker client/server 29.7.2 and fuse-overlayfs storage
