### PR TITLE
fix: derive Wolfi Podman runtime directory in CI

### DIFF
--- a/.github/workflows/build-devcontainers.yml
+++ b/.github/workflows/build-devcontainers.yml
@@ -188,7 +188,9 @@ jobs:
             command -v podman
             command -v buildah
             command -v skopeo
-            test "$(stat -c %a "${XDG_RUNTIME_DIR}")" = 700
+            runtime_dir="/run/user/$(id -u)"
+            test "$(stat -c %a "${runtime_dir}")" = 700
+            export XDG_RUNTIME_DIR="${runtime_dir}"
             podman_info="$(podman info --format "{{.Host.Security.Rootless}} {{.Store.GraphDriverName}} {{.Host.NetworkBackend}} {{.Host.CgroupManager}}")"
             test "${podman_info}" = "true overlay netavark cgroupfs"
             podman run --rm docker.io/library/alpine:3.22 sh -c "wget -q -O- https://example.com >/dev/null"

--- a/tests/wolfi-podman-contract-test.sh
+++ b/tests/wolfi-podman-contract-test.sh
@@ -66,5 +66,9 @@ assert_not_contains "${WORKFLOW}" 'docker ps --filter "ancestor=' \
     "Podman smoke does not reuse a prior step container"
 assert_contains "${WORKFLOW}" 'docker.io/library/alpine:3\.22' \
     "Podman smoke uses fully qualified Alpine image"
+assert_contains "${WORKFLOW}" 'runtime_dir="/run/user/\$\(id -u\)"' \
+    "Podman smoke derives runtime directory"
+assert_contains "${WORKFLOW}" 'export XDG_RUNTIME_DIR="\$\{runtime_dir\}"' \
+    "Podman smoke exports derived runtime directory"
 
 echo "Wolfi Podman contract tests passed"


### PR DESCRIPTION
## Summary

- derive the rootless Podman runtime directory inside the CI exec session
- verify its owner-only permissions and export `XDG_RUNTIME_DIR` before smoke commands
- add contract coverage for the exec-session environment boundary

## Root cause

The Wolfi image entrypoint exports `XDG_RUNTIME_DIR`, but later `docker exec` processes do not inherit environment changes made by PID 1. The publish smoke used `set -u` and referenced the missing variable, so it exited before invoking Podman.

Failed job: https://github.com/joshyorko/room-of-requirement/actions/runs/31958869813/job/95193751989

## Validation

- `tests/wolfi-podman-contract-test.sh`
- `tests/ror-docker-start-test.sh`
- Bash and workflow YAML syntax checks
- real Wolfi devcontainer build through `@devcontainers/cli`
- fresh privileged Docker `info` and `hello-world`
- fresh rootless Podman info, networking, CPU limit, bind mount, Buildah, and Skopeo checks
