### PR TITLE
fix: wait for Wolfi Podman runtime readiness

### DIFF
--- a/.github/workflows/build-devcontainers.yml
+++ b/.github/workflows/build-devcontainers.yml
@@ -189,6 +189,18 @@ jobs:
             command -v buildah
             command -v skopeo
             runtime_dir="/run/user/$(id -u)"
+            runtime_ready=0
+            for _ in $(seq 1 30); do
+              if [ -d "${runtime_dir}" ] && [ "$(stat -c %a "${runtime_dir}")" = 700 ]; then
+                runtime_ready=1
+                break
+              fi
+              sleep 1
+            done
+            if [ "${runtime_ready}" -ne 1 ]; then
+              echo "Podman runtime directory was not ready after 30 attempts: ${runtime_dir}" >&2
+              exit 1
+            fi
             test "$(stat -c %a "${runtime_dir}")" = 700
             export XDG_RUNTIME_DIR="${runtime_dir}"
             podman_info="$(podman info --format "{{.Host.Security.Rootless}} {{.Store.GraphDriverName}} {{.Host.NetworkBackend}} {{.Host.CgroupManager}}")"

--- a/tests/wolfi-podman-contract-test.sh
+++ b/tests/wolfi-podman-contract-test.sh
@@ -70,5 +70,11 @@ assert_contains "${WORKFLOW}" 'runtime_dir="/run/user/\$\(id -u\)"' \
     "Podman smoke derives runtime directory"
 assert_contains "${WORKFLOW}" 'export XDG_RUNTIME_DIR="\$\{runtime_dir\}"' \
     "Podman smoke exports derived runtime directory"
+assert_contains "${WORKFLOW}" 'for _ in \$\(seq 1 [0-9]+\); do' \
+    "Podman smoke bounds runtime directory wait"
+assert_contains "${WORKFLOW}" 'if \[ -d "\$\{runtime_dir\}" \] && \[ "\$\(stat -c %a "\$\{runtime_dir\}"\)" = 700 \]; then' \
+    "Podman smoke waits for secure runtime directory"
+assert_contains "${WORKFLOW}" 'Podman runtime directory was not ready after' \
+    "Podman smoke reports runtime directory timeout"
 
 echo "Wolfi Podman contract tests passed"


### PR DESCRIPTION
## Summary

- wait for the entrypoint-created rootless Podman runtime directory before smoke verification
- require the directory to exist with mode `700` within a bounded 30-attempt loop
- emit an explicit timeout failure and retain the final permission assertion

## Root cause

`docker run -d` returns as soon as the container starts, before its entrypoint necessarily creates `/run/user/$(id -u)`. The workflow immediately launched `docker exec`, so the permission assertion could race entrypoint initialization.

Failed job: https://github.com/joshyorko/room-of-requirement/actions/runs/31959533917/job/95195373591

## Validation

- reproduced the immediate fresh-container check failing before initialization
- confirmed the bounded condition wait succeeds and Podman reports `true overlay netavark cgroupfs`
- `tests/wolfi-podman-contract-test.sh`
- `tests/ror-docker-start-test.sh`
- Bash, workflow YAML, and diff checks
